### PR TITLE
Support for SalesOrder and SalesOrderLines

### DIFF
--- a/src/ExactOnline.Client.Models/Models.vb
+++ b/src/ExactOnline.Client.Models/Models.vb
@@ -3869,6 +3869,7 @@ Public Class SalesItemPrice
 End Class
 
 <DataServiceKey("OrderID")>
+<SupportedActionsSDK(True, True, True, True)>
 Public Class SalesOrder
 	Public Property [AmountDC] As Double?
 	Public Property [AmountFC] As Double?
@@ -3921,6 +3922,7 @@ Public Class SalesOrder
 End Class
 
 <DataServiceKey("ID")>
+<SupportedActionsSDK(True, True, True, True)>
 Public Class SalesOrderLine
 	Public Property [AmountDC] As Double?
 	Public Property [AmountFC] As Double?

--- a/src/ExactOnline.Client.Sdk/Helpers/ControllerList.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ControllerList.cs
@@ -106,9 +106,9 @@ namespace ExactOnline.Client.Sdk.Helpers
 					case "SalesEntryLine": conn = new ApiConnection(_connector, _apiEndpoint + "salesentry/SalesEntryLines"); break;
 					case "SalesInvoice": conn = new ApiConnection(_connector, _apiEndpoint + "salesinvoice/SalesInvoices"); break;
 					case "SalesInvoiceLine": conn = new ApiConnection(_connector, _apiEndpoint + "salesinvoice/SalesInvoiceLines"); break;
+					case "SalesItemPrice": conn = new ApiConnection(_connector, _apiEndpoint + "SalesItemPrice - Function Details"); break;
 					case "SalesOrder": conn = new ApiConnection(_connector, _apiEndpoint + "salesorder/SalesOrders"); break;
 					case "SalesOrderLine": conn = new ApiConnection(_connector, _apiEndpoint + "salesorder/SalesOrderLines"); break;
-					case "SalesItemPrice": conn = new ApiConnection(_connector, _apiEndpoint + "SalesItemPrice - Function Details"); break;
 					case "ShopOrder": conn = new ApiConnection(_connector, _apiEndpoint + "manufacturing/ShopOrders"); break;
 					case "ShopOrderMaterialPlan": conn = new ApiConnection(_connector, _apiEndpoint + "manufacturing/ShopOrderMaterialPlans"); break;
 					case "ShopOrderRoutingStepPlan": conn = new ApiConnection(_connector, _apiEndpoint + "manufacturing/ShopOrderRoutingStepPlans"); break;

--- a/src/ExactOnline.Client.Sdk/Helpers/ControllerList.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ControllerList.cs
@@ -106,6 +106,8 @@ namespace ExactOnline.Client.Sdk.Helpers
 					case "SalesEntryLine": conn = new ApiConnection(_connector, _apiEndpoint + "salesentry/SalesEntryLines"); break;
 					case "SalesInvoice": conn = new ApiConnection(_connector, _apiEndpoint + "salesinvoice/SalesInvoices"); break;
 					case "SalesInvoiceLine": conn = new ApiConnection(_connector, _apiEndpoint + "salesinvoice/SalesInvoiceLines"); break;
+					case "SalesOrder": conn = new ApiConnection(_connector, _apiEndpoint + "salesorder/SalesOrders"); break;
+					case "SalesOrderLine": conn = new ApiConnection(_connector, _apiEndpoint + "salesorder/SalesOrderLines"); break;
 					case "SalesItemPrice": conn = new ApiConnection(_connector, _apiEndpoint + "SalesItemPrice - Function Details"); break;
 					case "ShopOrder": conn = new ApiConnection(_connector, _apiEndpoint + "manufacturing/ShopOrders"); break;
 					case "ShopOrderMaterialPlan": conn = new ApiConnection(_connector, _apiEndpoint + "manufacturing/ShopOrderMaterialPlans"); break;


### PR DESCRIPTION
The SalesOrder and SalesOrderLines are already supported in the REST API for a while, but were still missing in the client API.