### PR TITLE
Set Culture to en-US before deserializing

### DIFF
--- a/src/ExactOnline.Client.Sdk/Helpers/ApiResponseCleaner.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ApiResponseCleaner.cs
@@ -26,10 +26,20 @@ namespace ExactOnline.Client.Sdk.Helpers
 		{
 			var serializer = new JavaScriptSerializer();
 			serializer.RegisterConverters(new JavaScriptConverter[] { new JssDateTimeConverter() });
-			var dict = (Dictionary<string, object>)serializer.Deserialize<object>(response);
+			var oldCulture = Thread.CurrentThread.CurrentCulture;
+            		Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
 
-			var d = (Dictionary<string, object>)dict["d"];
-			string output = GetJsonFromDictionary(d);
+		    	string output;
+		    	try
+		    	{
+		        	var dict = (Dictionary<string, object>)serializer.Deserialize<object>(response);
+		        	var d = (Dictionary<string, object>)dict["d"];
+		        	output = GetJsonFromDictionary(d);
+		    	}
+		    	finally
+		    	{
+                		Thread.CurrentThread.CurrentCulture = oldCulture;
+		    	}
 			return output;
 		}
 
@@ -42,7 +52,7 @@ namespace ExactOnline.Client.Sdk.Helpers
 			serializer.RegisterConverters(new JavaScriptConverter[] { new JssDateTimeConverter() });
 			
 			var oldCulture = Thread.CurrentThread.CurrentCulture;
-			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+			Thread.CurrentThread.CurrentCulture =CultureInfo.InvariantCulture;
 			try
 			{
 				ArrayList results;

--- a/src/ExactOnline.Client.Sdk/Helpers/ApiResponseCleaner.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ApiResponseCleaner.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Web.Script.Serialization;
 using ExactOnline.Client.Sdk.Exceptions;
 using Newtonsoft.Json;
+using System.Globalization;
+using System.Threading;
 
 namespace ExactOnline.Client.Sdk.Helpers
 {

--- a/src/ExactOnline.Client.Sdk/Helpers/ApiResponseCleaner.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ApiResponseCleaner.cs
@@ -38,6 +38,9 @@ namespace ExactOnline.Client.Sdk.Helpers
 		{
 			var serializer = new JavaScriptSerializer();
 			serializer.RegisterConverters(new JavaScriptConverter[] { new JssDateTimeConverter() });
+			
+			var oldCulture = Thread.CurrentThread.CurrentCulture;
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
 			try
 			{
 				ArrayList results;
@@ -57,6 +60,10 @@ namespace ExactOnline.Client.Sdk.Helpers
 			catch (Exception e)
 			{
 				throw new IncorrectJsonException(e.Message);
+			}
+			finally
+			{
+				Thread.CurrentThread.CurrentCulture = oldCulture;
 			}
 
 		}


### PR DESCRIPTION
When executing the GetJsonArray(string response) function the values of decimals/doubles are converted to the current culture format. If this culture has a ',' as decimal seperator the conversion at a later stage from JSON to object goes wrong.

The result is something like: "2850.5" is converted to "2850,5".
This happens in the following line of code "var dict = (Dictionary<string, object>)serializer.Deserialize<object>(response);"

Later on when you convert JSON to object, it will convert the "2850,5" value to "28505" because the JSON standard does not allow for a "," as decimal seperator.

Therefore before doing any deserialisation we should set the "CurrentCulture" to "en-US" in order to preserve the "." in decimals.