### PR TITLE
Cache current division in constructor of ExactOnlineClient

### DIFF
--- a/src/ExactOnline.Client.Sdk/Controllers/ExactOnlineClient.cs
+++ b/src/ExactOnline.Client.Sdk/Controllers/ExactOnlineClient.cs
@@ -14,6 +14,7 @@ namespace ExactOnline.Client.Sdk.Controllers
 		private readonly ApiConnector _apiConnector;
 		private readonly string _exactOnlineApiUrl;		// https://start.exactonline.nl/api/v1
 		private readonly ControllerList _controllers;
+		private int _division;
 
 		#region Constructors
 
@@ -32,8 +33,8 @@ namespace ExactOnline.Client.Sdk.Controllers
 			if (!exactOnlineUrl.EndsWith("/")) exactOnlineUrl += "/";
 			_exactOnlineApiUrl = exactOnlineUrl + "api/v1/";
 
-			int currentDivision = (division > 0) ? division : GetDivision();
-			string serviceRoot = _exactOnlineApiUrl + currentDivision + "/";
+			_division = (division > 0) ? division : GetDivision();
+			string serviceRoot = _exactOnlineApiUrl + _division + "/";
 
 			_controllers = new ControllerList(_apiConnector, serviceRoot);
 		}
@@ -72,11 +73,18 @@ namespace ExactOnline.Client.Sdk.Controllers
 		/// <returns>Division number</returns>
 		public int GetDivision()
 		{
+			if (_division > 0)
+			{
+				return _division;
+			}
+
 			var currentMe = CurrentMe();
 			if (currentMe != null)
 			{
-				return currentMe.CurrentDivision;
+				_division = currentMe.CurrentDivision;
+				return _division;
 			}
+
 			throw new Exception("Cannot get division. Please specify division explicitly via the constructor.");
 		}
 
@@ -90,6 +98,5 @@ namespace ExactOnline.Client.Sdk.Controllers
 		}
 
 		#endregion
-
 	}
 }


### PR DESCRIPTION
If no division is sent to the constructor of ExactOnlineClient, it is retrieved by calling GetDivision. GetDivision calls CurrentMe to find the division. This division is not cached in the controller though, which means that if we want to retrieve the current division again, it will have to call CurrentMe again.

Maybe it's worth caching CurrentMe instead, in which case I'll create a pull request for that instead. CurrentMe is often called in the ExactOnlineClient constructor to retrieve the division, but it is not cached. This means that we'll need a second CurrentMe call to retrieve the CurrentMe from the client.