### PR TITLE
Make ID property of direct debit mandate optional

### DIFF
--- a/src/ExactOnline.Client.Models/Models.vb
+++ b/src/ExactOnline.Client.Models/Models.vb
@@ -2008,7 +2008,7 @@ Public Class DirectDebitMandate
 	'''<![CDATA[Indicates the first collection hasn't been sent/confirmed with this mandate.]]>
 	Public Property [FirstSend] As Byte?
 	'''<![CDATA[Primary key]]>
-	Public Property [ID] As Guid
+	Public Property [ID] As Guid?
 	'''<![CDATA[Last modified date]]>
 	<SDKFieldType(FieldType.ReadOnly)>
 	Public Property [Modified] As DateTime?


### PR DESCRIPTION
It should be possible to create a direct debit mandate without an ID. Currently it's not possible to create a new direct debit mandate because "00000000-0000-0000-0000-000000000000" gets filled in as the ID.

Ticket reference: 01085800