### PR TITLE
Allow query parameters in count()

### DIFF
--- a/src/ExactOnline.Client.Sdk/Controllers/Controller.cs
+++ b/src/ExactOnline.Client.Sdk/Controllers/Controller.cs
@@ -60,9 +60,9 @@ namespace ExactOnline.Client.Sdk.Controllers
 		/// <summary>
 		/// Returns the number of entities of the current type
 		/// </summary>
-		public int Count()
+		public int Count(string query)
 		{
-			return _conn.Count();
+			return _conn.Count(query);
 		}
 
 		/// <summary>

--- a/src/ExactOnline.Client.Sdk/Helpers/ApiConnection.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ApiConnection.cs
@@ -164,12 +164,13 @@ namespace ExactOnline.Client.Sdk.Helpers
 		}
 
 		/// <summary>
-		/// Counts the number of resources/entities
+        /// Counts the number of resources/entities, including parameters
 		/// </summary>
+        /// <param name="parameters">Parameters</param>
 		/// <returns></returns>
-		public int Count()
+        public int Count(string parameters)
 		{
-			string response = _conn.DoCleanRequest(EndPoint + "/$count");
+            string response = _conn.DoCleanRequest(EndPoint + "/$count", parameters);
 			return int.Parse(response);
 		}
 	}

--- a/src/ExactOnline.Client.Sdk/Helpers/ApiConnector.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ApiConnector.cs
@@ -169,7 +169,7 @@ namespace ExactOnline.Client.Sdk.Helpers
 
 		#region Private methods
 
-		private HttpWebRequest CreateRequest(string url, string oDataQuery, RequestTypeEnum method)
+		private HttpWebRequest CreateRequest(string url, string oDataQuery, RequestTypeEnum method, string acceptContentType = "application/json")
 		{
 			if (!string.IsNullOrEmpty(oDataQuery))
 			{
@@ -179,7 +179,10 @@ namespace ExactOnline.Client.Sdk.Helpers
 			var request = (HttpWebRequest)WebRequest.Create(url);
 			request.Method = method.ToString();
 			request.ContentType = "application/json";
-			request.Accept = "application/json";
+			if (!string.IsNullOrEmpty(acceptContentType))
+			{
+				request.Accept = acceptContentType;
+			}
 			request.Headers.Add("Authorization", "Bearer " + _accessTokenDelegate());
 
 			return request;
@@ -242,6 +245,24 @@ namespace ExactOnline.Client.Sdk.Helpers
 			return responseValue;
 		}
 
+
+		/// <summary>
+		/// Request without 'Accept' Header, including parameters
+		/// </summary>
+		/// <param name="uri"></param>
+		/// <param name="oDataQuery"></param>
+		/// <returns></returns>
+		public string DoCleanRequest(string uri, string oDataQuery)
+		{
+			if (string.IsNullOrEmpty(uri)) throw new ArgumentException("Cannot perform request with empty endpoint");
+
+			var request = CreateRequest(uri, oDataQuery, RequestTypeEnum.GET, null);
+
+			Debug.WriteLine("GET ");
+			Debug.WriteLine(request.RequestUri);
+
+			return GetResponse(request);
+		}
 		#endregion
 
 	}

--- a/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
@@ -196,7 +196,7 @@ namespace ExactOnline.Client.Sdk.Helpers
 		/// <returns></returns>
 		public int Count()
 		{
-			return _controller.Count();
+			return _controller.Count(CreateODataQuery(false));
 		}
 
 

--- a/src/ExactOnline.Client.Sdk/Interfaces/IAPIConnection.cs
+++ b/src/ExactOnline.Client.Sdk/Interfaces/IAPIConnection.cs
@@ -5,7 +5,7 @@ namespace ExactOnline.Client.Sdk.Interfaces
 	public interface IApiConnection
 	{
 		string Get(string parameters);
-		
+
 		string GetEntity(string keyname, string guid, string parameters);
 
 		string Post(string data);
@@ -14,7 +14,7 @@ namespace ExactOnline.Client.Sdk.Interfaces
 
 		Boolean Delete(string keyName, string guid);
 
-		int Count();
+		int Count(string parameters);
 
 	}
 }

--- a/src/ExactOnline.Client.Sdk/Interfaces/IAPIConnector.cs
+++ b/src/ExactOnline.Client.Sdk/Interfaces/IAPIConnector.cs
@@ -11,6 +11,7 @@
 		string DoDeleteRequest(string endpoint);
 
 		string DoCleanRequest(string uri); // Request without Content-Type for $count function
+		string DoCleanRequest(string uri, string oDataQuery); // Request without Content-Type for $count function, including parameters
 
 		int GetCurrentDivision(string website);
 	}

--- a/src/ExactOnline.Client.Sdk/Interfaces/IController.cs
+++ b/src/ExactOnline.Client.Sdk/Interfaces/IController.cs
@@ -16,7 +16,7 @@ namespace ExactOnline.Client.Sdk.Interfaces
 
 		Boolean Delete(T entity);
 
-		int Count(); // For $count function API
+		int Count(string query); // For $count function API
 
 		void RegistrateLinkedEntityField(string fieldname);
 	}

--- a/test/ExactOnline.Client.Sdk.UnitTests/MockObjects/ApiConnectionEntityControllerMock.cs
+++ b/test/ExactOnline.Client.Sdk.UnitTests/MockObjects/ApiConnectionEntityControllerMock.cs
@@ -5,7 +5,7 @@ namespace ExactOnline.Client.Sdk.UnitTests.MockObjects
 {
 	public sealed class ApiConnectionEntityControllerMock : IApiConnection
 	{
-		public int Count()
+		public int Count(string parameters)
 		{
 			return 0;
 		}

--- a/test/ExactOnline.Client.Sdk.UnitTests/MockObjects/ApiConnectionMock.cs
+++ b/test/ExactOnline.Client.Sdk.UnitTests/MockObjects/ApiConnectionMock.cs
@@ -6,7 +6,7 @@ namespace ExactOnline.Client.Sdk.UnitTests.MockObjects
 	{
 		#region IApiConnection Members
 
-		int IApiConnection.Count()
+		int IApiConnection.Count(string parameters)
 		{
 			return 0;
 		}

--- a/test/ExactOnline.Client.Sdk.UnitTests/MockObjects/ApiConnectorControllerMock.cs
+++ b/test/ExactOnline.Client.Sdk.UnitTests/MockObjects/ApiConnectorControllerMock.cs
@@ -14,6 +14,11 @@ namespace ExactOnline.Client.Sdk.UnitTests.MockObjects
 			return "";
 		}
 
+		public string DoCleanRequest(string uri, string oDataQuery)
+		{
+			return "";
+		}
+
 		public string DoGetRequest(string endpoint, string parameters)
 		{
 			return @"{
@@ -138,6 +143,5 @@ namespace ExactOnline.Client.Sdk.UnitTests.MockObjects
 		{
 			return -1;
 		}
-
 	}
 }

--- a/test/ExactOnline.Client.Sdk.UnitTests/MockObjects/ApiConnectorMock.cs
+++ b/test/ExactOnline.Client.Sdk.UnitTests/MockObjects/ApiConnectorMock.cs
@@ -7,7 +7,7 @@ namespace ExactOnline.Client.Sdk.UnitTests.MockObjects
 	/// <summary>
 	/// Simulates APIConnector class
 	/// </summary>
-	public class ApiConnectorMock : IApiConnector 
+	public class ApiConnectorMock : IApiConnector
 	{
 		public String Data { get; set; }
 
@@ -16,6 +16,10 @@ namespace ExactOnline.Client.Sdk.UnitTests.MockObjects
 			return "";
 		}
 
+		public string DoCleanRequest(string uri, string oDataQuery)
+		{
+			return "";
+		}
 
 		public int Count()
 		{

--- a/test/ExactOnline.Client.Sdk.UnitTests/MockObjects/ControllerMock.cs
+++ b/test/ExactOnline.Client.Sdk.UnitTests/MockObjects/ControllerMock.cs
@@ -8,7 +8,7 @@ namespace ExactOnline.Client.Sdk.UnitTests.MockObjects
 	public sealed class ControllerMock<T> : IController<T>
 	{
 
-		public int Count()
+		public int Count(string query)
 		{
 			return 0;
 		}


### PR DESCRIPTION
This allows you to pass query parameters for a `Count()` operation.

Examples:

```csharp
var count = client
                    .For<Account>()
                    .Where("Created ge datetime'2014-01-01' or Modified ge datetime'2014-01-01'")
                    .Count();
```

```csharp
var count = client
                    .For<SalesInvoice>()
                    .Where("Status eq 50 and InvoiceTo eq guid'0a18dc63-4a99-41b0-a64f-b7daee96127b'")
                    .Count();
```