### PR TITLE
CreateODataQuery Logical AND issue, EntityController Clone improvement

### DIFF
--- a/src/ExactOnline.Client.Sdk/Controllers/EntityController.cs
+++ b/src/ExactOnline.Client.Sdk/Controllers/EntityController.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using ExactOnline.Client.Sdk.Delegates;
 using ExactOnline.Client.Sdk.Helpers;
 using ExactOnline.Client.Sdk.Interfaces;
+using System.Linq;
 
 namespace ExactOnline.Client.Sdk.Controllers
 {
@@ -62,7 +63,8 @@ namespace ExactOnline.Client.Sdk.Controllers
 		private static object Clone(object entity)
 		{
 			object returnEntity = Activator.CreateInstance(entity.GetType(), null);
-			foreach (var property in entity.GetType().GetProperties())
+			var writableProperties = entity.GetType().GetProperties().Where(p => p.CanWrite);
+			foreach (var property in writableProperties)
 			{
 				var value = property.GetValue(entity);
 				if (value != null && value.GetType().IsGenericType && value is IEnumerable)

--- a/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
@@ -62,12 +62,11 @@ namespace ExactOnline.Client.Sdk.Helpers
 
 			if (!string.IsNullOrEmpty(_where))
 			{
+				if (_and != null && _and.Count > 0) {
+					_where += string.Format("+and+{0}", string.Join("+and+", _and));
+				}				
 				queryParts.Add(_where);
 			}
-
-			// Add $filter
-			queryParts.AddRange(_and);
-
 
 			// Add $select
 			if (!string.IsNullOrEmpty(_select))

--- a/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
@@ -62,7 +62,8 @@ namespace ExactOnline.Client.Sdk.Helpers
 
 			if (!string.IsNullOrEmpty(_where))
 			{
-				if (_and != null && _and.Count > 0) {
+				if (_and != null && _and.Count > 0) 
+				{
 					_where += string.Format("+and+{0}", string.Join("+and+", _and));
 				}				
 				queryParts.Add(_where);

--- a/test/ExactOnline.Client.Sdk.UnitTests/ExactOnlineQueryTest.cs
+++ b/test/ExactOnline.Client.Sdk.UnitTests/ExactOnlineQueryTest.cs
@@ -32,8 +32,8 @@ namespace ExactOnline.Client.Sdk.UnitTests
 				.And("Code+eq+'123'")
 				.And("Code+eq+'456'")
 				.Get();
-
-			Assert.AreEqual("$filter=Name+eq+'Test Testname'&Code+eq+'123'&Code+eq+'456'&$select=Code,Name", _controllerMock.ODataQuery);
+			
+			Assert.AreEqual("$filter=Name+eq+'Test Testname'+and+Code+eq+'123'+and+Code+eq+'456'&$select=Code,Name", _controllerMock.ODataQuery);
 		}
 
 		[TestMethod]
@@ -208,9 +208,8 @@ namespace ExactOnline.Client.Sdk.UnitTests
 				.Expand("BankAccounts")
 				.Skip(10)
 				.Top(10).Get();
-
-
-			const string expected = "$filter=Name+eq+'Test'&Name+eq+'Test2'&$select=Description,Name&$skip=10&$expand=BankAccounts&$top=10";
+				
+			const string expected = "$filter=Name+eq+'Test'+and+Name+eq+'Test2'&$select=Description,Name&$skip=10&$expand=BankAccounts&$top=10";
 			var data = _controllerMock.ODataQuery;
 			Assert.AreEqual(expected, data);
 		}


### PR DESCRIPTION
Two Commits for your consideration:

**1. ExactOnlineQuery.CreateODataQuery:** 
AND is added as a query part list element which gets joined to a querystring by &. For example: 

$filter=City+eq+'AMSTERDAM'&AccountIsSupplier+eq+true.  

This results in an incorrect where clause of the form "where x and y and z". For this construction to function correctly the filter should be defined as follows:

$filter=City+eq+'AMSTERDAM'+and+AccountIsSupplier+eq+true  

Which gets correctly translated to:  SELECT *  FROM ExactOnline.Addresses WHERE (City = 'Amsterdam') AND (AccountIsSupplier = True)

**2. EnitityController.Clone:**
The clone method tries to set property values of non writeable properties (ie properties with only a public getter). Method now only loops over Properties where CanWrite == true.

