### PR TITLE
Strongly typed queries

### DIFF
--- a/src/ExactOnline.Client.Sdk/Enums/OperatorEnum.cs
+++ b/src/ExactOnline.Client.Sdk/Enums/OperatorEnum.cs
@@ -6,7 +6,7 @@ namespace ExactOnline.Client.Sdk.Enums
         /// <summary>
         /// Equal
         /// </summary>
-        eq,
+        Eq,
         /// <summary>
         /// Not equal
         /// </summary>

--- a/src/ExactOnline.Client.Sdk/Enums/OperatorEnum.cs
+++ b/src/ExactOnline.Client.Sdk/Enums/OperatorEnum.cs
@@ -1,0 +1,63 @@
+﻿
+namespace ExactOnline.Client.Sdk.Enums
+{
+    public enum OperatorEnum
+    {
+        /// <summary>
+        /// Equal
+        /// </summary>
+        eq,
+        /// <summary>
+        /// Not equal
+        /// </summary>
+        Ne,
+        /// <summary>
+        /// Greater than
+        /// </summary>
+        Gt,
+        /// <summary>
+        /// Greater than or equal
+        /// </summary>
+        Ge,
+        /// <summary>
+        /// Less than
+        /// </summary>
+        Lt,
+        /// <summary>
+        /// Less than or equal
+        /// </summary>
+        Le,
+        /// <summary>
+        /// Logical and
+        /// </summary>
+        And,
+        /// <summary>
+        /// Logical or
+        /// </summary>
+        Or,
+        /// <summary>
+        /// Logical negation
+        /// </summary>
+        Not,
+        /// <summary>
+        /// Addition	
+        /// </summary>
+        Add,
+        /// <summary>
+        /// Subtraction	
+        /// </summary>
+        Sub,
+        /// <summary>
+        /// Multiplication
+        /// </summary>
+        Mul,
+        /// <summary>
+        /// Division
+        /// </summary>
+        Div,
+        /// <summary>
+        /// Modulo
+        /// </summary>
+        Mod,
+    }
+}

--- a/src/ExactOnline.Client.Sdk/ExactOnline.Client.Sdk.csproj
+++ b/src/ExactOnline.Client.Sdk/ExactOnline.Client.Sdk.csproj
@@ -45,6 +45,7 @@
     <Compile Include="Controllers\SimpleController.cs" />
     <Compile Include="Delegates\AccessTokenManagerDelegate.cs" />
     <Compile Include="Delegates\GetEntityControllerDelegate.cs" />
+    <Compile Include="Enums\OperatorEnum.cs" />
     <Compile Include="Helpers\ApiConnection.cs" />
     <Compile Include="Helpers\ApiConnector.cs" />
     <Compile Include="Helpers\ApiResponseCleaner.cs" />
@@ -66,6 +67,9 @@
     <Compile Include="Interfaces\IApiConnector.cs" />
     <Compile Include="Interfaces\IController.cs" />
     <Compile Include="Interfaces\IEntityManager.cs" />
+    <Compile Include="Models\ServerMessage.cs" />
+    <Compile Include="Models\ServerMessageError.cs" />
+    <Compile Include="Models\ServerMessageErrorMessage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ExactOnline.Client.Sdk/Helpers/ControllerList.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ControllerList.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
+using ExactOnline.Client.Models;
 using ExactOnline.Client.Sdk.Controllers;
 using ExactOnline.Client.Sdk.Interfaces;
 
 namespace ExactOnline.Client.Sdk.Helpers
 {
-	using System.Collections.Generic;
-
-	using ExactOnline.Client.Models;
-
 	/// <summary>
 	/// Manages instances of controllers
 	/// </summary>
@@ -51,7 +49,7 @@ namespace ExactOnline.Client.Sdk.Helpers
 			{
 				ApiConnection conn;
 
-				if (typename == typeof(Models.Current.Me).FullName)
+				if (typename == typeof(ExactOnline.Client.Models.Current.Me).FullName)
 				{
 					conn = new ApiConnection(_connector, _baseUrl + "system/Me");
 				}

--- a/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
@@ -349,6 +349,8 @@ namespace ExactOnline.Client.Sdk.Helpers
                     _value = $"guid'{value}'";
                 else if (type == typeof(DateTime))
                     _value = $"datetime'{value:s}'";
+                else if (type == typeof(bool))
+                    _value = value.ToString().ToLower();
                 else
                     _value = value.ToString();
             }

--- a/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using ExactOnline.Client.Sdk.Interfaces;
 using System.Linq.Expressions;
 using ExactOnline.Client.Sdk.Enums;
+using System.Linq;
 
 namespace ExactOnline.Client.Sdk.Helpers
 {
@@ -128,9 +129,9 @@ namespace ExactOnline.Client.Sdk.Helpers
 		/// </summary>
         /// <param name="property">The property to select</param>
 		/// <returns></returns>
-        public ExactOnlineQuery<T> Select<TProperty>(Expression<Func<T, TProperty>> property)
+        public ExactOnlineQuery<T> Select<TProperty>(params Expression<Func<T, TProperty>>[] property)
 		{
-            return Select(fields: TransformExpressionToODataFormat(property));
+            return Select(fields: property.Select(x => TransformExpressionToODataFormat(x)).ToArray());
 		}
 
 		/// <summary>

--- a/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
@@ -293,14 +293,21 @@ namespace ExactOnline.Client.Sdk.Helpers
         /// </summary>
         string ToODataFormat<T>(T value)
         {
-            string _value = value?.ToString();
+            string _value = null;
 
-            if (value is string)
-                _value = $"'{value}'";
-            else if (value is Guid)
-                _value = $"guid'{value}'";
-            else if (value is DateTime)
-                _value = $"datetime'{value:s}'";
+            if (value != null)
+            {
+                var type = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+
+                if (type == typeof(string))
+                    _value = $"'{value}'";
+                else if (type == typeof(Guid))
+                    _value = $"guid'{value}'";
+                else if (type == typeof(DateTime))
+                    _value = $"datetime'{value:s}'";
+                else
+                    _value = _value.ToString();
+            }
 
             return _value;
         }

--- a/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
@@ -34,16 +34,7 @@ namespace ExactOnline.Client.Sdk.Helpers
         /// </summary>
         public ExactOnlineQuery<T> Where<TProperty>(Expression<Func<T, TProperty>> property, TProperty value, OperatorEnum @operator = OperatorEnum.eq)
         {
-            string _value = value?.ToString();
-
-            if (value is string)
-                _value = $"'{value}'";
-            else if (value is Guid)
-                _value = $"guid'{value}'";
-            else if (value is DateTime)
-                _value = $"datetime'{value:s}'";
-
-            return Where($"{GetPropertyName(property)}+{@operator}+{_value}");
+            return Where($"{GetPropertyName(property)}+{@operator}+{ToODataFormat(value)}");
         }
 
         /// <summary>
@@ -61,7 +52,7 @@ namespace ExactOnline.Client.Sdk.Helpers
         /// </summary>
         public ExactOnlineQuery<T> And<TProperty>(Expression<Func<T, TProperty>> property, TProperty value, OperatorEnum @operator = OperatorEnum.eq)
         {
-            return And($"{GetPropertyName(property)}+{@operator}+'{value}'");
+            return And($"{GetPropertyName(property)}+{@operator}+{ToODataFormat(value)}");
         }
 
         /// <summary>
@@ -143,9 +134,9 @@ namespace ExactOnline.Client.Sdk.Helpers
 		}
 
 		/// <summary>
-		/// Specify the fields to get from the API
+		/// Specify the field(s) to get from the API
 		/// </summary>
-		/// <param name="fields">Name of fields</param>
+		/// <param name="fields">The field(s) to get</param>
 		/// <returns></returns>
 		public ExactOnlineQuery<T> Select(params string[] fields)
 		{
@@ -194,7 +185,7 @@ namespace ExactOnline.Client.Sdk.Helpers
 		}
 
 		/// <summary>
-		/// Specify the fields to order by
+		/// Specify the field(s) to order by
 		/// </summary>
 		/// <param name="orderby"></param>
 		/// <returns></returns>
@@ -296,6 +287,23 @@ namespace ExactOnline.Client.Sdk.Helpers
 			if (entity == null) throw new ArgumentException("Insert entity: Entity cannot be null");
 			return _controller.Create(ref entity);
 		}
+
+        /// <summary>
+        /// Formats any given value to it's OData-compliant string representation.
+        /// </summary>
+        string ToODataFormat<T>(T value)
+        {
+            string _value = value?.ToString();
+
+            if (value is string)
+                _value = $"'{value}'";
+            else if (value is Guid)
+                _value = $"guid'{value}'";
+            else if (value is DateTime)
+                _value = $"datetime'{value:s}'";
+
+            return _value;
+        }
 
         /// <summary>
         /// Returns the name for the given property expression.

--- a/src/ExactOnline.Client.Sdk/Models/ServerMessage.cs
+++ b/src/ExactOnline.Client.Sdk/Models/ServerMessage.cs
@@ -1,0 +1,7 @@
+﻿namespace ExactOnline.Client.Sdk.Models
+{
+    internal class ServerMessage
+    {
+        public ServerMessageError Error { get; set; }
+    }
+}

--- a/src/ExactOnline.Client.Sdk/Models/ServerMessageError.cs
+++ b/src/ExactOnline.Client.Sdk/Models/ServerMessageError.cs
@@ -1,0 +1,8 @@
+﻿namespace ExactOnline.Client.Sdk.Models
+{
+    internal class ServerMessageError
+    {
+        public string Code { get; set; }
+        public ServerMessageErrorMessage Message { get; set; }
+    }
+}

--- a/src/ExactOnline.Client.Sdk/Models/ServerMessageErrorMessage.cs
+++ b/src/ExactOnline.Client.Sdk/Models/ServerMessageErrorMessage.cs
@@ -1,0 +1,8 @@
+﻿namespace ExactOnline.Client.Sdk.Models
+{
+    internal class ServerMessageErrorMessage
+    {
+        public string Lang { get; set; }
+        public string Value { get; set; }
+    }
+}


### PR DESCRIPTION
Added support for strongly typed calls to the ExactOnlineQuery API methods Where, And, Select and OrderBy. 

Also made a minor change to the methods Select and OrderBy to allow for multiple calls to these methods, allowing the concaternation of multiple Select and OrderBy calls to append multiple fields, resulting in a more fluent API.