### PR TITLE
Implemented Minutely-Limit headers.

### DIFF
--- a/src/ExactOnline.Client.Sdk/Helpers/ApiConnector.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ApiConnector.cs
@@ -460,7 +460,9 @@ namespace ExactOnline.Client.Sdk.Helpers
                 {
                     Limit = response.Headers["X-RateLimit-Limit"].ToNullableInt(),
                     Remaining = response.Headers["X-RateLimit-Remaining"].ToNullableInt(),
-                    Reset = response.Headers["X-RateLimit-Reset"].ToNullableLong()
+                    Reset = response.Headers["X-RateLimit-Reset"].ToNullableLong(),
+                    MinutelyLimit = response.Headers["X-RateLimit-Minutely-Limit"].ToNullableInt(),
+                    MinutelyRemaining = response.Headers["X-RateLimit-Minutely-Remaining"].ToNullableInt()
                 }
             };
 

--- a/src/ExactOnline.Client.Sdk/Models/RateLimit.cs
+++ b/src/ExactOnline.Client.Sdk/Models/RateLimit.cs
@@ -21,5 +21,13 @@
         /// The time at which the rate limit window resets in UTC epoch seconds.
         /// </summary>
         public long? Reset { get; set; }
+        /// <summary>
+        /// The maximum number of API calls you're permitted to make per app, per company, per minute.
+        /// </summary>
+        public int? MinutelyLimit { get; set; }
+        /// <summary>
+        /// The number of API calls remaining within the minutely rate limit window of an app and company.
+        /// </summary>
+        public int? MinutelyRemaining { get; set; }
     }
 }


### PR DESCRIPTION
The Minutely limit headers were not implemented yet in the ApiConnector class.