### PR TITLE
Added InsertWithoutReadback method

### DIFF
--- a/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineQuery.cs
@@ -370,12 +370,25 @@ namespace ExactOnline.Client.Sdk.Helpers
         }
 
         /// <summary>
-        /// Inserts the specified entity into Exact Online
+        /// Inserts the specified entity into Exact Online and updates the entity passed as argument
+        /// The cost of this method is 2 API calls
+        /// ExactOnline only supports 60 API calls per minute
+        /// If this limit is a concern, use InsertWithoutReadback instead
         /// </summary>
         public Boolean Insert(ref T entity)
         {
             if (entity == null) throw new ArgumentException("Insert entity: Entity cannot be null");
             return _controller.Create(ref entity);
+        }
+
+        /// <summary>
+        /// Inserts the specified entity into Exact Online
+        /// </summary>
+        public Boolean InsertWithoutReadback(T entity)
+        {
+            if (entity == null)
+                throw new ArgumentException("Insert entity: Entity cannot be null");
+            return _controller.CreateWithoutReadback(entity);
         }
 
         /// <summary>

--- a/src/ExactOnline.Client.Sdk/Interfaces/IController.cs
+++ b/src/ExactOnline.Client.Sdk/Interfaces/IController.cs
@@ -12,6 +12,7 @@ namespace ExactOnline.Client.Sdk.Interfaces
         Task<T> GetEntityAsync(string guid, string parameters);
 
         Boolean Create(ref T entity);
+        Boolean CreateWithoutReadback(T entity);
         Task<T> CreateAsync(T entity);
 
         Boolean Update(T entity);


### PR DESCRIPTION
We use the ExactOnlineClient for our requests. However, due to the API Limit of a maximum of 60 calls per minute imposed by ExactOnline, we have been running into trouble. We have been able to fix our end so that it makes a maximum of 60 calls to the ExactOnlineClient, however, even so some calls failed, specifically those that were using the `Insert` method.

I investigated this and figured out that the `Insert` method actually makes two calls: The insert call and the readback call. Since we do not need the latter for our purposes and this causes us to run into the limit twice as fast (aka, makes our application take twice as long to insert a long list of entities), I hereby propose this alternate InsertWithoutReadback method as an alternative that can be used when the number of API calls becomes a critical bottleneck.